### PR TITLE
Add exponential backoff for deregistering task definitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Build artifacts
         run: |
-          CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags "-s -X main.Version=TEST" -a -o build/Linux/go-ecs-cleaner .
-          CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -X main.Version=TEST" -a -o build/macOS/go-ecs-cleaner .
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -X main.Version=TEST" -a -o build/Windows/go-ecs-cleaner.exe .
+          CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags "-s -X main.Version=${{ github.ref }}" -a -o build/Linux/go-ecs-cleaner .
+          CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -X main.Version=${{ github.ref }}" -a -o build/macOS/go-ecs-cleaner .
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -X main.Version=${{ github.ref }}" -a -o build/Windows/go-ecs-cleaner.exe .
+          for os in Linux macOS Windows ; do cd build && zip -r ${os}.zip ${os} && cd .. ; done
 
       - name: Create release
         id: create_release
@@ -39,8 +40,8 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Linux binary
-        id: upload-linux-binary
+      - name: Upload Linux assets
+        id: upload-linux-assets
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,28 +50,28 @@ jobs:
             # This pulls from the `Create release` step above, referencing its ID to get its outputs object,
             # which includes an `upload_url`. See this blog post for more info:
             # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./build/Linux/go-ecs-cleaner
-          asset_name: go-ecs-cleaner-linux
+          asset_path: ./build/Linux.zip
+          asset_name: go-ecs-cleaner-linux.zip
           asset_content_type: application/zip
 
-      - name: Upload macOS binary
-        id: upload-macos-binary
+      - name: Upload macOS assets
+        id: upload-macos-assets
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
-          asset_path: ./build/macOS/go-ecs-cleaner
-          asset_name: go-ecs-cleaner-darwin
+          asset_path: ./build/macOS.zip
+          asset_name: go-ecs-cleaner-macos.zip
           asset_content_type: application/zip
 
-      - name: Upload Windows binary
-        id: upload-windows-binary
+      - name: Upload Windows assets
+        id: upload-windows-assets
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
-          asset_path: ./build/Windows/go-ecs-cleaner.exe
-          asset_name: go-ecs-cleaner-windows.exe
+          asset_path: ./build/Windows.zip
+          asset_name: go-ecs-cleaner-windows.zip
           asset_content_type: application/zip

--- a/cmd/ecs_task.go
+++ b/cmd/ecs_task.go
@@ -21,6 +21,10 @@ the AWS CLI for the AWS account you want to clean up.`,
 			os.Exit(1)
 		}
 
+		if debugFlag {
+			verboseFlag = true
+		}
+
 		flags := map[string]interface{}{
 			"apply":    applyFlag,
 			"cutoff":   cutoffFlag,

--- a/cmd/ecs_task.go
+++ b/cmd/ecs_task.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/quintilesims/go-ecs-cleaner/ecstask"
 	"github.com/spf13/cobra"
 )
@@ -13,9 +16,15 @@ var ecsTaskCmd = &cobra.Command{
 BEFORE RUNNING: Make sure that you've properly configured your environment with
 the AWS CLI for the AWS account you want to clean up.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if parallelFlag < 1 {
+			fmt.Println("minimum parallel is 1")
+			os.Exit(1)
+		}
+
 		flags := map[string]interface{}{
 			"apply":    applyFlag,
 			"cutoff":   cutoffFlag,
+			"debug":    debugFlag,
 			"parallel": parallelFlag,
 			"region":   regionFlag,
 			"verbose":  verboseFlag,
@@ -27,6 +36,7 @@ the AWS CLI for the AWS account you want to clean up.`,
 
 var applyFlag bool
 var cutoffFlag int
+var debugFlag bool
 var parallelFlag int
 var regionFlag string
 var verboseFlag bool
@@ -34,7 +44,8 @@ var verboseFlag bool
 func init() {
 	ecsTaskCmd.Flags().BoolVarP(&applyFlag, "apply", "a", false, "actually perform task definition deregistration")
 	ecsTaskCmd.Flags().IntVarP(&cutoffFlag, "cutoff", "c", 5, "how many most-recent task definitions to keep around")
-	ecsTaskCmd.Flags().IntVarP(&parallelFlag, "parallel", "p", 10, "how many concurrent deregistration requests to make")
+	ecsTaskCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false, "enable for all the output")
+	ecsTaskCmd.Flags().IntVarP(&parallelFlag, "parallel", "p", 2, "how many concurrent deregistration requests to make")
 	ecsTaskCmd.Flags().StringVarP(&regionFlag, "region", "r", "us-west-2", "the AWS region in which to operate")
 	ecsTaskCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "enable for chattier output")
 	rootCmd.AddCommand(ecsTaskCmd)

--- a/ecstask/ecs_task.go
+++ b/ecstask/ecs_task.go
@@ -2,7 +2,6 @@ package ecstask
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -414,94 +413,94 @@ type Result struct {
 }
 
 func deregisterTaskDefinitions(svc *ecs.ECS, taskDefinitionArns []string, parallel int, debug bool) {
-	worker := func(wg *sync.WaitGroup, jobsChan <-chan Job, resultsChan chan<- Result) {
-		for job := range jobsChan {
-			input := &ecs.DeregisterTaskDefinitionInput{
-				TaskDefinition: aws.String(job.Arn),
-			}
-
-			_, err := svc.DeregisterTaskDefinition(input)
-
-			result := Result{Arn: job.Arn, Err: err}
-			resultsChan <- result
-		}
-
-		wg.Done()
-	}
-
-	dispatcher := func(wg *sync.WaitGroup, arns []string, parallel int, jobsChan chan Job, resultsChan chan Result) {
-		jobs := stack.New()
-		for _, arn := range arns {
-			jobs.Push(Job{arn})
-		}
-
-		var completedJobs int
-
-		preload := 1
-		if parallel > 1 {
-			preload = parallel - 1
-		}
-
-		for i := 0; i < preload; i++ {
-			jobsChan <- jobs.Pop().(Job)
-		}
-
-		b := &backoff.Backoff{
-			Min:    100 * time.Millisecond,
-			Max:    2 * time.Minute,
-			Jitter: true,
-		}
-
-		for result := range resultsChan {
-			if result.Err != nil {
-				if !isThrottlingError(result.Err) {
-					fmt.Println("\nError deregistering task definition,", result.Err)
-					close(jobsChan)
-					close(resultsChan)
-					wg.Done()
-					os.Exit(1)
-				}
-
-				t := b.Duration()
-				if debug {
-					fmt.Printf("\nbackoff triggered for %s,", result.Arn)
-					fmt.Printf("\nwaiting for %v\n", t)
-				}
-
-				time.Sleep(t)
-				jobs.Push(Job{Arn: result.Arn})
-			} else {
-				b.Reset()
-				completedJobs++
-				fmt.Printf("\r%d deregistered task definitions", completedJobs)
-			}
-
-			if jobs.Len() > 0 {
-				jobsChan <- jobs.Pop().(Job)
-			}
-
-			if completedJobs == len(arns) {
-				close(jobsChan)
-				close(resultsChan)
-			}
-		}
-
-		wg.Done()
-	}
-
 	jobsChan := make(chan Job, parallel)
 	resultsChan := make(chan Result, parallel)
 
 	var wg sync.WaitGroup
 	for i := 0; i < parallel; i++ {
 		wg.Add(1)
-		go worker(&wg, jobsChan, resultsChan)
+		go worker(svc, &wg, jobsChan, resultsChan)
 	}
 
 	wg.Add(1)
-	go dispatcher(&wg, taskDefinitionArns, parallel, jobsChan, resultsChan)
+	go dispatcher(&wg, taskDefinitionArns, parallel, jobsChan, resultsChan, debug)
 
 	wg.Wait()
+}
+
+func worker(svc *ecs.ECS, wg *sync.WaitGroup, jobsChan <-chan Job, resultsChan chan<- Result) {
+	for job := range jobsChan {
+		input := &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: aws.String(job.Arn),
+		}
+
+		_, err := svc.DeregisterTaskDefinition(input)
+
+		result := Result{Arn: job.Arn, Err: err}
+		resultsChan <- result
+	}
+
+	wg.Done()
+}
+
+func dispatcher(wg *sync.WaitGroup, arns []string, parallel int, jobsChan chan Job, resultsChan chan Result, debug bool) {
+	jobs := stack.New()
+	for _, arn := range arns {
+		jobs.Push(Job{arn})
+	}
+
+	var completedJobs int
+
+	preload := 1
+	if parallel > 1 {
+		preload = parallel - 1
+	}
+
+	for i := 0; i < preload; i++ {
+		jobsChan <- jobs.Pop().(Job)
+	}
+
+	b := &backoff.Backoff{
+		Min:    100 * time.Millisecond,
+		Max:    2 * time.Minute,
+		Jitter: true,
+	}
+
+	for result := range resultsChan {
+		if result.Err != nil {
+			if !isThrottlingError(result.Err) {
+				fmt.Println("\nError deregistering task definition,", result.Err)
+				close(jobsChan)
+				close(resultsChan)
+				wg.Done()
+				return
+			}
+
+			t := b.Duration()
+			if debug {
+				fmt.Printf("\nbackoff triggered for %s,", result.Arn)
+				fmt.Printf("\nwaiting for %v\n", t)
+			}
+
+			time.Sleep(t)
+			jobs.Push(Job{Arn: result.Arn})
+		} else {
+			b.Reset()
+			completedJobs++
+			fmt.Printf("\r%d deregistered task definitions", completedJobs)
+		}
+
+		if jobs.Len() > 0 {
+			jobsChan <- jobs.Pop().(Job)
+		}
+
+		if completedJobs == len(arns) {
+			close(jobsChan)
+			close(resultsChan)
+		}
+	}
+
+	wg.Done()
 }
 
 func isThrottlingError(err error) bool {

--- a/ecstask/ecs_task.go
+++ b/ecstask/ecs_task.go
@@ -502,62 +502,6 @@ func deregisterTaskDefinitions(svc *ecs.ECS, taskDefinitionArns []string, parall
 	go dispatcher(&wg, taskDefinitionArns, parallel, jobsChan, resultsChan)
 
 	wg.Wait()
-
-	// worker := func(wg *sync.WaitGroup) {
-	// 	for arn := range arnsChan {
-	// 		deregisterTaskDefinition(arn, throttledChan, countChan)
-	// 	}
-
-	// 	wg.Done()
-	// }
-
-	// progressTracker := func(countChan <-chan int) {
-	// 	var counter int
-	// 	fmt.Printf("\r%d task definitions deregistered", counter)
-
-	// 	for i := range countChan {
-	// 		counter += i
-	// 		//fmt.Printf("\r%d task definitions deregistered", counter)
-	// 	}
-	// }
-
-	// dispatcher := func(arns []string, arnsChan chan<- string, throttledChan <-chan bool) {
-	// 	b := &backoff.Backoff{
-	// 		Min:    100 * time.Millisecond,
-	// 		Max:    5 * time.Minute,
-	// 		Jitter: true,
-	// 	}
-
-	// 	for _, arn := range arns {
-	// 		for throttled := range throttledChan {
-	// 			fmt.Printf("%t\n", throttled)
-	// 			if throttled {
-	// 				fmt.Printf("waiting for %v\n", b.Duration())
-	// 			} else {
-	// 				fmt.Printf("resetting\n")
-	// 				b.Reset()
-	// 			}
-	// 		}
-	// 	}
-
-	// }
-
-	// arnsChan := make(chan string, len(taskDefinitionArns))
-	// countChan := make(chan int, parallel)
-	// throttledChan := make(chan bool, parallel)
-
-	// go dispatcher(taskDefinitionArns, arnsChan, throttledChan)
-	// go progressTracker(countChan)
-
-	// var wg sync.WaitGroup
-	// for i := 0; i < parallel; i++ {
-	// 	wg.Add(1)
-	// 	go worker(&wg)
-	// }
-
-	// wg.Wait()
-	// close(countChan)
-	// close(throttledChan)
 }
 
 func isThrottlingError(err error) bool {

--- a/ecstask/ecs_task.go
+++ b/ecstask/ecs_task.go
@@ -2,13 +2,18 @@ package ecstask
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/golang-collections/collections/stack"
+	"github.com/jpillora/backoff"
 	"github.com/spf13/cobra"
 )
 
@@ -269,9 +274,9 @@ func Run(cmd *cobra.Command, args []string, flags map[string]interface{}) {
 		fmt.Println("\n`--apply` flag present")
 		fmt.Printf("deregistering %d task definitions...\n", len(allTaskDefinitionArns))
 
-		deregisterTaskDefinitions(svc, allTaskDefinitionArns, flags["parallel"].(int))
+		deregisterTaskDefinitions(svc, allTaskDefinitionArns, flags["parallel"].(int), flags["debug"].(bool))
 
-		fmt.Println("finished")
+		fmt.Println("\nfinished")
 	} else {
 		fmt.Println("\nthis is a dry run")
 		fmt.Println("use the `--apply` flag to deregister these task definitions")
@@ -397,44 +402,177 @@ func removeAFromB(a, b []string) []string {
 	return diff
 }
 
-func deregisterTaskDefinitions(svc *ecs.ECS, taskDefinitionArns []string, parallel int) {
-	arnsChan := make(chan string, len(taskDefinitionArns))
+// Job carries information through a Job channel.
+type Job struct {
+	Arn string
+}
 
-	deregisterTaskDefinition := func(arn string) {
-		_, err := svc.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: aws.String(arn),
-		})
-		if err != nil {
-			fmt.Println("Error deregistering task definition:", err)
-		}
-	}
+// Result carries informatino through a Result chan.
+type Result struct {
+	Arn string
+	Err error
+}
 
-	worker := func(wg *sync.WaitGroup) {
-		for arn := range arnsChan {
-			deregisterTaskDefinition(arn)
+func deregisterTaskDefinitions(svc *ecs.ECS, taskDefinitionArns []string, parallel int, debug bool) {
+	worker := func(wg *sync.WaitGroup, jobsChan <-chan Job, resultsChan chan<- Result) {
+		for job := range jobsChan {
+			input := &ecs.DeregisterTaskDefinitionInput{
+				TaskDefinition: aws.String(job.Arn),
+			}
+
+			_, err := svc.DeregisterTaskDefinition(input)
+
+			result := Result{Arn: job.Arn, Err: err}
+			resultsChan <- result
 		}
 
 		wg.Done()
 	}
 
-	createWorkerPool := func(numWorkers int) {
-		var wg sync.WaitGroup
-		for i := 0; i < numWorkers; i++ {
-			wg.Add(1)
-			go worker(&wg)
-		}
-
-		wg.Wait()
-	}
-
-	allocate := func(arns []string) {
+	dispatcher := func(wg *sync.WaitGroup, arns []string, parallel int, jobsChan chan Job, resultsChan chan Result) {
+		jobs := stack.New()
 		for _, arn := range arns {
-			arnsChan <- arn
+			jobs.Push(Job{arn})
 		}
 
-		close(arnsChan)
+		var completedJobs int
+
+		preload := 1
+		if parallel > 1 {
+			preload = parallel - 1
+		}
+
+		for i := 0; i < preload; i++ {
+			jobsChan <- jobs.Pop().(Job)
+		}
+
+		b := &backoff.Backoff{
+			Min:    100 * time.Millisecond,
+			Max:    2 * time.Minute,
+			Jitter: true,
+		}
+
+		for result := range resultsChan {
+			if result.Err != nil {
+				if !isThrottlingError(result.Err) {
+					fmt.Println("\nError deregistering task definition,", result.Err)
+					close(jobsChan)
+					close(resultsChan)
+					wg.Done()
+					os.Exit(1)
+				}
+
+				t := b.Duration()
+				if debug {
+					fmt.Printf("\nbackoff triggered for %s,", result.Arn)
+					fmt.Printf("\nwaiting for %v\n", t)
+				}
+
+				time.Sleep(t)
+				jobs.Push(Job{Arn: result.Arn})
+			} else {
+				b.Reset()
+				completedJobs++
+				fmt.Printf("\r%d deregistered task definitions", completedJobs)
+			}
+
+			if jobs.Len() > 0 {
+				jobsChan <- jobs.Pop().(Job)
+			}
+
+			if completedJobs == len(arns) {
+				close(jobsChan)
+				close(resultsChan)
+			}
+		}
+
+		wg.Done()
 	}
 
-	go allocate(taskDefinitionArns)
-	createWorkerPool(parallel)
+	jobsChan := make(chan Job, parallel)
+	resultsChan := make(chan Result, parallel)
+
+	var wg sync.WaitGroup
+	for i := 0; i < parallel; i++ {
+		wg.Add(1)
+		go worker(&wg, jobsChan, resultsChan)
+	}
+
+	wg.Add(1)
+	go dispatcher(&wg, taskDefinitionArns, parallel, jobsChan, resultsChan)
+
+	wg.Wait()
+
+	// worker := func(wg *sync.WaitGroup) {
+	// 	for arn := range arnsChan {
+	// 		deregisterTaskDefinition(arn, throttledChan, countChan)
+	// 	}
+
+	// 	wg.Done()
+	// }
+
+	// progressTracker := func(countChan <-chan int) {
+	// 	var counter int
+	// 	fmt.Printf("\r%d task definitions deregistered", counter)
+
+	// 	for i := range countChan {
+	// 		counter += i
+	// 		//fmt.Printf("\r%d task definitions deregistered", counter)
+	// 	}
+	// }
+
+	// dispatcher := func(arns []string, arnsChan chan<- string, throttledChan <-chan bool) {
+	// 	b := &backoff.Backoff{
+	// 		Min:    100 * time.Millisecond,
+	// 		Max:    5 * time.Minute,
+	// 		Jitter: true,
+	// 	}
+
+	// 	for _, arn := range arns {
+	// 		for throttled := range throttledChan {
+	// 			fmt.Printf("%t\n", throttled)
+	// 			if throttled {
+	// 				fmt.Printf("waiting for %v\n", b.Duration())
+	// 			} else {
+	// 				fmt.Printf("resetting\n")
+	// 				b.Reset()
+	// 			}
+	// 		}
+	// 	}
+
+	// }
+
+	// arnsChan := make(chan string, len(taskDefinitionArns))
+	// countChan := make(chan int, parallel)
+	// throttledChan := make(chan bool, parallel)
+
+	// go dispatcher(taskDefinitionArns, arnsChan, throttledChan)
+	// go progressTracker(countChan)
+
+	// var wg sync.WaitGroup
+	// for i := 0; i < parallel; i++ {
+	// 	wg.Add(1)
+	// 	go worker(&wg)
+	// }
+
+	// wg.Wait()
+	// close(countChan)
+	// close(throttledChan)
+}
+
+func isThrottlingError(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		code := awsErr.Code()
+
+		if code == "Throttling" || code == "ThrottlingException" {
+			return true
+		}
+
+		message := strings.ToLower(awsErr.Message())
+		if code == "ClientException" && strings.Contains(message, "too many concurrent attempts") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/ecstask/ecs_task.go
+++ b/ecstask/ecs_task.go
@@ -407,7 +407,7 @@ type Job struct {
 	Arn string
 }
 
-// Result carries informatino through a Result chan.
+// Result carries information through a Result channel.
 type Result struct {
 	Arn string
 	Err error

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.25.34
+	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+	github.com/jpillora/backoff v1.0.0
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,16 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 h1:zN2lZNZRflqFyxVaTIU61KNKQ9C0055u9CAfpmqUvo4=
+github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3/go.mod h1:nPpo7qLxd6XL3hWJG/O60sR8ZKfMCiIoNap5GvD12KU=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/vendor/github.com/golang-collections/collections/LICENSE
+++ b/vendor/github.com/golang-collections/collections/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Caleb Doxsey
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/golang-collections/collections/stack/stack.go
+++ b/vendor/github.com/golang-collections/collections/stack/stack.go
@@ -1,0 +1,44 @@
+package stack
+
+type (
+	Stack struct {
+		top *node
+		length int
+	}
+	node struct {
+		value interface{}
+		prev *node
+	}	
+)
+// Create a new stack
+func New() *Stack {
+	return &Stack{nil,0}
+}
+// Return the number of items in the stack
+func (this *Stack) Len() int {
+	return this.length
+}
+// View the top item on the stack
+func (this *Stack) Peek() interface{} {
+	if this.length == 0 {
+		return nil
+	}
+	return this.top.value
+}
+// Pop the top item of the stack and return it
+func (this *Stack) Pop() interface{} {
+	if this.length == 0 {
+		return nil
+	}
+	
+	n := this.top
+	this.top = n.prev
+	this.length--
+	return n.value
+}
+// Push a value onto the top of the stack
+func (this *Stack) Push(value interface{}) {
+	n := &node{value,this.top}
+	this.top = n
+	this.length++
+}

--- a/vendor/github.com/jpillora/backoff/LICENSE
+++ b/vendor/github.com/jpillora/backoff/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jaime Pillora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jpillora/backoff/README.md
+++ b/vendor/github.com/jpillora/backoff/README.md
@@ -1,0 +1,119 @@
+# Backoff
+
+A simple exponential backoff counter in Go (Golang)
+
+[![GoDoc](https://godoc.org/github.com/jpillora/backoff?status.svg)](https://godoc.org/github.com/jpillora/backoff) [![Circle CI](https://circleci.com/gh/jpillora/backoff.svg?style=shield)](https://circleci.com/gh/jpillora/backoff)
+
+### Install
+
+```
+$ go get -v github.com/jpillora/backoff
+```
+
+### Usage
+
+Backoff is a `time.Duration` counter. It starts at `Min`. After every call to `Duration()` it is  multiplied by `Factor`. It is capped at `Max`. It returns to `Min` on every call to `Reset()`. `Jitter` adds randomness ([see below](#example-using-jitter)). Used in conjunction with the `time` package.
+
+---
+
+#### Simple example
+
+``` go
+
+b := &backoff.Backoff{
+	//These are the defaults
+	Min:    100 * time.Millisecond,
+	Max:    10 * time.Second,
+	Factor: 2,
+	Jitter: false,
+}
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+200ms
+400ms
+Reset!
+100ms
+```
+
+---
+
+#### Example using `net` package
+
+``` go
+b := &backoff.Backoff{
+    Max:    5 * time.Minute,
+}
+
+for {
+	conn, err := net.Dial("tcp", "example.com:5309")
+	if err != nil {
+		d := b.Duration()
+		fmt.Printf("%s, reconnecting in %s", err, d)
+		time.Sleep(d)
+		continue
+	}
+	//connected
+	b.Reset()
+	conn.Write([]byte("hello world!"))
+	// ... Read ... Write ... etc
+	conn.Close()
+	//disconnected
+}
+
+```
+
+---
+
+#### Example using `Jitter`
+
+Enabling `Jitter` adds some randomization to the backoff durations. [See Amazon's writeup of performance gains using jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html). Seeding is not necessary but doing so gives repeatable results.
+
+```go
+import "math/rand"
+
+b := &backoff.Backoff{
+	Jitter: true,
+}
+
+rand.Seed(42)
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+106.600049ms
+281.228155ms
+Reset!
+100ms
+104.381845ms
+214.957989ms
+```
+
+#### Documentation
+
+https://godoc.org/github.com/jpillora/backoff
+
+#### Credits
+
+Forked from [some JavaScript](https://github.com/segmentio/backo) written by [@tj](https://github.com/tj)

--- a/vendor/github.com/jpillora/backoff/backoff.go
+++ b/vendor/github.com/jpillora/backoff/backoff.go
@@ -1,0 +1,100 @@
+// Package backoff provides an exponential-backoff implementation.
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	attempt uint64
+	// Factor is the multiplying factor for each increment step
+	Factor float64
+	// Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	// Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// Duration returns the duration for the current attempt before incrementing
+// the attempt counter. See ForAttempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(float64(atomic.AddUint64(&b.attempt, 1) - 1))
+	return d
+}
+
+const maxInt64 = float64(math.MaxInt64 - 512)
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, attempt)
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	atomic.StoreUint64(&b.attempt, 0)
+}
+
+// Attempt returns the current attempt counter value.
+func (b *Backoff) Attempt() float64 {
+	return float64(atomic.LoadUint64(&b.attempt))
+}
+
+// Copy returns a backoff with equals constraints as the original
+func (b *Backoff) Copy() *Backoff {
+	return &Backoff{
+		Factor: b.Factor,
+		Jitter: b.Jitter,
+		Min:    b.Min,
+		Max:    b.Max,
+	}
+}

--- a/vendor/github.com/jpillora/backoff/go.mod
+++ b/vendor/github.com/jpillora/backoff/go.mod
@@ -1,0 +1,3 @@
+module github.com/jpillora/backoff
+
+go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,10 +33,14 @@ github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
 github.com/aws/aws-sdk-go/service/ecs
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
+# github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+github.com/golang-collections/collections/stack
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
+# github.com/jpillora/backoff v1.0.0
+github.com/jpillora/backoff
 # github.com/spf13/cobra v0.0.5
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3


### PR DESCRIPTION
Makes use of channels and a backoff struct in order to handle AWS rate limiting errors when making calls to deregister task definitions. Works regardless of how many parallel routines you wish to run, though it should be noted that there are dramatically diminishing performance returns after `-p=2` or `-p=3`. AWS has their own backoff built into the endpoint we're using, and we've implemented one on our side to handle the cases when the AWS rate limiter isn't enough, and there's no endpoint for batch deregistration, so this is probably as good as we'll get.